### PR TITLE
Use include instead of require

### DIFF
--- a/clippy.lua
+++ b/clippy.lua
@@ -1,6 +1,6 @@
-local state = require("clippy/lib/state")
-local sequencer = require("clippy/lib/sequencer")
-local display = require("clippy/lib/display")
+local state = include("clippy/lib/state")
+local sequencer = include("clippy/lib/sequencer")
+local display = include("clippy/lib/display")
 
 engine.name = "PolyPerc"
 

--- a/lib/state.lua
+++ b/lib/state.lua
@@ -1,4 +1,4 @@
-local utils = require("clippy/lib/utils")
+local utils = include("clippy/lib/utils")
 local state = {
     tracks = {},
     scale = nil,


### PR DESCRIPTION
`require()` will hang onto the module between script reloads
`include()` always reloads the referenced module